### PR TITLE
fixed: TSDLWindow::GetWindowHandle always returned null

### DIFF
--- a/sdlvideo.mod/glue.c
+++ b/sdlvideo.mod/glue.c
@@ -20,6 +20,7 @@
     3. This notice may not be removed or altered from any source
     distribution.
 */
+#include "SDL_config.h"
 #include "SDL_video.h"
 #include "SDL_syswm.h"
 


### PR DESCRIPTION
SDL_config.h wasn't included, so the ifdef driver checks in bmx_sdl_video_GetWindowHandle() were all skipped, resulting in a NULL return

This looks to be the only glue file in sdl.mod that needs SDL_config.h, although we might want to add it to others too just to be neat.

We should probably also put wayland checks in this function too, but no clue if that works or needs adjustments elsewhere to work (can't test that yet)