### PR TITLE
Add SDL_SetHintWithPriority and custom SDLPrioritizeRenderer()

### DIFF
--- a/sdl.mod/common.bmx
+++ b/sdl.mod/common.bmx
@@ -111,6 +111,8 @@ Extern
 	Function SDL_HasClipboardText:Int()
 	Function bmx_SDL_GetClipboardText:String()
 	Function SDL_SetClipboardText:Int(Text:Byte Ptr)
+
+	Function SDL_SetHintWithPriority:Int(name:Byte Ptr, value:Byte Ptr, priority:ESDLHintPriority)
 	
 	Function SDL_Log(txt:Byte Ptr)
 	Function SDL_LogCritical(category:Int, txt:Byte Ptr)
@@ -354,4 +356,14 @@ Enum SDL_BlendFactor
     SDL_BLENDFACTOR_ONE_MINUS_DST_COLOR = $8  ' 1-dstR, 1-dstG, 1-dstB, 1-dstA
     SDL_BLENDFACTOR_DST_ALPHA           = $9  ' dstA, dstA, dstA, dstA
     SDL_BLENDFACTOR_ONE_MINUS_DST_ALPHA = $A  ' 1-dstA, 1-dstA, 1-dstA, 1-dstA
+End Enum
+
+
+Rem
+bbdoc: The different hint priorities defined by SDL.
+End Rem
+Enum ESDLHintPriority
+	SDL_HINT_DEFAULT  ' low priority, used for default values
+	SDL_HINT_NORMAL   ' medium priority
+	SDL_HINT_OVERRIDE ' high priority
 End Enum

--- a/sdl.mod/sdl.bmx
+++ b/sdl.mod/sdl.bmx
@@ -602,5 +602,17 @@ Function SDLIsTablet:Int()
 	Return SDL_IsTablet()
 End Function
 
+Rem
+bbdoc: Returns #True if the hint was set.
+End Rem
+Function SDLSetHintWithPriority:Int(name:String, value:string, priority:ESDLHintPriority)
+	Local n:Byte Ptr = name.ToUTF8String()
+	Local v:Byte Ptr = value.ToUTF8String()
+	Local result:int = SDL_SetHintWithPriority(n, v, priority)
+	MemFree n
+	MemFree v
+	Return result
+End Function
+
 ' shutdown all the subsystems
 atexit_(SDL_Quit)

--- a/sdlrendermax2d.mod/sdlrendermax2d.bmx
+++ b/sdlrendermax2d.mod/sdlrendermax2d.bmx
@@ -517,3 +517,20 @@ Function SDLSetPreferredRenderer( renderer:String )
 	Next
 	_preferredRenderer = -1
 End Function
+
+
+Rem
+bbdoc: Marks a renderer to be prioritized over others, by name.
+about: Available renderers vary by platform. If @renderer is not found or
+       cannot be initialized later then, normal default will be used.
+End Rem
+Function SDLPrioritizeRenderer( renderer:String, priority:ESDLHintPriority = ESDLHintPriority.SDL_HINT_DEFAULT)
+	For Local i:int = 0 Until SDLGetNumRenderDrivers()
+		Local info:SDLRendererInfo
+		SDLGetRenderDriverInfo(i, info)
+		If info.GetName() = renderer Then
+			SDLSetHintWithPriority("SDL_RENDER_DRIVER", renderer, priority)
+			Exit
+		End If
+	Next
+End Function


### PR DESCRIPTION
Allows you to use eg:
```
SDLPrioritizeRenderer("software")
```
before issuing your `graphics` command ... and so tell SDL to prioritize "software" over "opengl" (or similar).

Also this adds support for `SDL_SetHintWithPriority()`.