### PR TITLE
Fix: [Brl.D3D9xxx] Reapplied SuperStrict-corrections

### DIFF
--- a/d3d9sdlgraphics.mod/d3d9sdlgraphics.bmx
+++ b/d3d9sdlgraphics.mod/d3d9sdlgraphics.bmx
@@ -84,7 +84,7 @@ Function OpenD3DDevice:Int( hwnd:Byte Ptr,width:Int,height:Int,depth:Int,hertz:I
 	
 	'_d3dDev' = New IDirect3DDevice9
 
-	Function CheckDepthFormat(format:Int)
+	Function CheckDepthFormat:Int(format:Int)
 	    Return _d3d.CheckDeviceFormat(0,D3DDEVTYPE_HAL,D3DFMT_X8R8G8B8,D3DUSAGE_DEPTHSTENCIL,D3DRTYPE_SURFACE,format)=D3D_OK
 	End Function
 

--- a/d3d9sdlmax2d.mod/d3d9sdlmax2d.bmx
+++ b/d3d9sdlmax2d.mod/d3d9sdlmax2d.bmx
@@ -450,7 +450,7 @@ Type TD3D9RenderImageFrame Extends TD3D9ImageFrame
 		For Local y:Int = 0 Until pixmap.height
 			Local srcptr:Byte Ptr = pixmap.pixels + y * pixmap.pitch
 			Local dstptr:Byte Ptr = lockedrect.pBits + y * lockedrect.Pitch
-			MemCopy dstptr, srcptr, pixmap.width * 4
+			MemCopy dstptr, srcptr, Size_T(pixmap.width * 4)
 		Next
 		stage.UnlockRect()
 
@@ -650,7 +650,7 @@ Type TD3D9RenderImage Extends TRenderImage
 			_d3ddev.SetRenderState(D3DRS_SCISSORTESTENABLE, False)
 		Else
 			_d3ddev.SetRenderState(D3DRS_SCISSORTESTENABLE, True)
-			Local rect[] = [x , y, x + width, y + height]
+			Local rect:Int[] = [x , y, x + width, y + height]
 			_d3ddev.SetScissorRect(rect)
 		EndIf
 


### PR DESCRIPTION
Must have slipped through in my PR for r2t.

Afterwards current sdl.mod compiles completely with current BCC/BMK again.