### PR TITLE
Fix: [SDL.mod] call bbThreadUnregister for SDL_Threads (regression)

### DIFF
--- a/sdl.mod/SDL/src/thread/SDL_thread.c
+++ b/sdl.mod/SDL/src/thread/SDL_thread.c
@@ -296,6 +296,9 @@ void SDL_RunThread(SDL_Thread *thread)
     /* Run the function */
     *statusloc = userfunc(userdata);
 
+	/* unregister with BlitzMax */
+	bbThreadUnregister(bbThread);
+
     /* Clean up thread-local storage */
     SDL_TLSCleanup();
 


### PR DESCRIPTION
Seems the Commit adding 2.28.0 missed to call bbThreadUnregister(bbThread) as the prior version (modded...) did.

Edit: The indentation of the code is copied from the previous version of the file - just if you wonder (and it corresponds to the indentation of the bbThreadRegister-call - to emphasize "blitzmax changes" in the file)

Fixes #58 